### PR TITLE
Fix/min sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,11 +5,15 @@ def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.2"
 def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_SUPPORT_LIB_VERSION             = "26.1.0"
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion safeExtGet("minSdkVersion", 21)
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Build issue appeared with the migration to RN73. Fix matching project minSdkVersion.

```
> Task :react-native-wheel-picker-android:processDebugAndroidTestManifest FAILED
/Users/arnaudderosin/natureglobal/nature-app/node_modules/react-native-wheel-picker-android/android/build/intermediates/tmp/manifest/androidTest/debug/tempFile1ProcessTestManifest2924038853637093126.xml:5:5-74 Error:
	uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.73.11] /Users/arnaudderosin/.gradle/caches/transforms-3/b7b7745f11e1000428691879d09e4340/transformed/jetified-react-android-0.73.11-debug/AndroidManifest.xml as the library might be using APIs not available in 16
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 21,
		or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```